### PR TITLE
fix: MTL pkgc_wake_cause and pkgc_block_cause

### DIFF
--- a/xml/MTL/0/mtl_aggregator_interface.xml
+++ b/xml/MTL/0/mtl_aggregator_interface.xml
@@ -17,20 +17,6 @@
 			</TransFormParameters>
 			<transform>$parameter_0 / 38.4 * 1e6 </transform>
 		</TransFormation>
-		<TransFormation name="pkgc_wake_cause" transformID="pkgc_wake_cause">
-			<output_dataclass>float</output_dataclass>
-			<TransFormParameters>
-				<parameterName>parameter_0</parameterName>
-			</TransFormParameters>
-			<transform>$parameter_0 / PACKAGE_CSTATE_WAKE_REFCNT * 100 </transform>
-		</TransFormation>
-		<TransFormation name="pkgc_block_cause" transformID="pkgc_block_cause">
-			<output_dataclass>float</output_dataclass>
-			<TransFormParameters>
-				<parameterName>parameter_0</parameterName>
-			</TransFormParameters>
-			<transform>$parameter_0 / PACKAGE_CSTATE_BLOCK_REFCNT * 100 </transform>
-		</TransFormation>
 		<TransFormation name="wp_volts" transformID="wp_volts">
 			<output_dataclass>float</output_dataclass>
 			<TransFormParameters>
@@ -248,7 +234,7 @@
 	<TELI:uniqueid>0x130670B2</TELI:uniqueid>
 	<TELI:NDA>Public</TELI:NDA>
 	<TELI:samplePeriod>10</TELI:samplePeriod>
-	<TELI:revisionDate>2023-11-28</TELI:revisionDate>
+	<TELI:revisionDate>2024-09-06</TELI:revisionDate>
 	<TELI:AggregatorSamples>
 		<TELI:T_AggregatorSample sampleName="VPU_MEMORY_BW" sampleGroup="VPU_MEMORY_BW" datatypeIDREF="tbw_KB" sampleID="0">
 			<TELI:description>Average DDR BW over a time interval (VPU counts in KB)</TELI:description>

--- a/xml/MTL/0/mtl_common.xml
+++ b/xml/MTL/0/mtl_common.xml
@@ -25,6 +25,20 @@
 			</TELC:units>
 		<TELC:format>ANY</TELC:format>
 	</TELC:dataType>
+	<TELC:dataType name="tdiec_wake_cause" datatypeID="tdiec_wake_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
+	<TELC:dataType name="tdiec_block_cause" datatypeID="tdiec_block_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
 	<TELC:dataType name="twp_volts" datatypeID="twp_volts">
 		<TELC:dataclass>status</TELC:dataclass>
 			<TELC:units name="volts">

--- a/xml/MTL/1/mtl_aggregator_interface.xml
+++ b/xml/MTL/1/mtl_aggregator_interface.xml
@@ -250,7 +250,7 @@
 	<TELI:uniqueid>0x130671B2</TELI:uniqueid>
 	<TELI:NDA>Public</TELI:NDA>
 	<TELI:samplePeriod>10</TELI:samplePeriod>
-	<TELI:revisionDate>2023-11-28</TELI:revisionDate>
+	<TELI:revisionDate>2024-09-06</TELI:revisionDate>
 	<TELI:AggregatorSamples>
 		<TELI:T_AggregatorSample sampleName="EXTENDED_TELE_ID_SPECIFIC_HEADER" sampleGroup="EXTENDED_TELE_ID_SPECIFIC_HEADER" datatypeIDREF="tgeneric_counter" sampleID="0">
 			<TELI:description>NOT a counter. Indicates the format of extended fixed telemetry regionBits 7:0 - NUM_RAW_BLOCK_REASONS - Number of counters in &quot;raw block reasons&quot; sub-categoryBits 15:8 - NUM_RAW_WAKE_REASONS_PC6_PC10Bits 23:16 - NUM_DEMOTION_CAUSES_PC6_PC10Bits 31:24 - NUM_BLOCK_CAUSES_PC6_PC10</TELI:description>

--- a/xml/MTL/1/mtl_common.xml
+++ b/xml/MTL/1/mtl_common.xml
@@ -25,6 +25,20 @@
 			</TELC:units>
 		<TELC:format>ANY</TELC:format>
 	</TELC:dataType>
+	<TELC:dataType name="tdiec_wake_cause" datatypeID="tdiec_wake_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
+	<TELC:dataType name="tdiec_block_cause" datatypeID="tdiec_block_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
 	<TELC:dataType name="twp_volts" datatypeID="twp_volts">
 		<TELC:dataclass>status</TELC:dataclass>
 			<TELC:units name="volts">

--- a/xml/MTL/2/mtl_aggregator_interface.xml
+++ b/xml/MTL/2/mtl_aggregator_interface.xml
@@ -17,20 +17,6 @@
 			</TransFormParameters>
 			<transform>$parameter_0 / 38.4 * 1e6 </transform>
 		</TransFormation>
-		<TransFormation name="pkgc_wake_cause" transformID="pkgc_wake_cause">
-			<output_dataclass>float</output_dataclass>
-			<TransFormParameters>
-				<parameterName>parameter_0</parameterName>
-			</TransFormParameters>
-			<transform>$parameter_0 / PACKAGE_CSTATE_WAKE_REFCNT * 100 </transform>
-		</TransFormation>
-		<TransFormation name="pkgc_block_cause" transformID="pkgc_block_cause">
-			<output_dataclass>float</output_dataclass>
-			<TransFormParameters>
-				<parameterName>parameter_0</parameterName>
-			</TransFormParameters>
-			<transform>$parameter_0 / PACKAGE_CSTATE_BLOCK_REFCNT * 100 </transform>
-		</TransFormation>
 		<TransFormation name="wp_volts" transformID="wp_volts">
 			<output_dataclass>float</output_dataclass>
 			<TransFormParameters>
@@ -248,7 +234,7 @@
 	<TELI:uniqueid>0x1A067002</TELI:uniqueid>
 	<TELI:NDA>Public</TELI:NDA>
 	<TELI:samplePeriod>10</TELI:samplePeriod>
-	<TELI:revisionDate>2023-11-28</TELI:revisionDate>
+	<TELI:revisionDate>2024-09-06</TELI:revisionDate>
 	<TELI:AggregatorSamples>
 		<TELI:T_AggregatorSample sampleName="LOCAL_VERSION" sampleGroup="GLOBAL_ID" datatypeIDREF="tgeneric_sample" sampleID="0">
 			<TELI:description>revision of the xml</TELI:description>

--- a/xml/MTL/2/mtl_common.xml
+++ b/xml/MTL/2/mtl_common.xml
@@ -25,6 +25,20 @@
 			</TELC:units>
 		<TELC:format>ANY</TELC:format>
 	</TELC:dataType>
+	<TELC:dataType name="tdiec_wake_cause" datatypeID="tdiec_wake_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
+	<TELC:dataType name="tdiec_block_cause" datatypeID="tdiec_block_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
 	<TELC:dataType name="twp_volts" datatypeID="twp_volts">
 		<TELC:dataclass>status</TELC:dataclass>
 			<TELC:units name="volts">

--- a/xml/MTL/3/mtl_aggregator.xml
+++ b/xml/MTL/3/mtl_aggregator.xml
@@ -49,7 +49,7 @@
 	<TELEM:SampleGroup name="Container_2" sampleID="2" sampleGroupID="Container_2">
 		<TELC:description>Groupname 0x16010</TELC:description>
 		<TELC:length>64</TELC:length>
-		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_CORE" datatypeIDREF="tpkgc_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_CORE">
+		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_CORE" datatypeIDREF="tdiec_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_CORE">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by CORE</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_BLOCK_CAUSE_CORE</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -57,7 +57,7 @@
 			<TELC:lsb>0</TELC:lsb>
 			<TELC:msb>31</TELC:msb>
 		</TELC:sample>
-		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_RING" datatypeIDREF="tpkgc_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_RING">
+		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_RING" datatypeIDREF="tdiec_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_RING">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by RING</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_BLOCK_CAUSE_RING</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -69,7 +69,7 @@
 	<TELEM:SampleGroup name="Container_3" sampleID="3" sampleGroupID="Container_3">
 		<TELC:description>Groupname 0x16018</TELC:description>
 		<TELC:length>64</TELC:length>
-		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_GPSB" datatypeIDREF="tpkgc_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_GPSB">
+		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_GPSB" datatypeIDREF="tdiec_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_GPSB">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by GPSB</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_BLOCK_CAUSE_GPSB</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -77,7 +77,7 @@
 			<TELC:lsb>0</TELC:lsb>
 			<TELC:msb>31</TELC:msb>
 		</TELC:sample>
-		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_PUNIT" datatypeIDREF="tpkgc_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_PUNIT">
+		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_PUNIT" datatypeIDREF="tdiec_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_PUNIT">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by PUNIT</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_BLOCK_CAUSE_PUNIT</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -89,7 +89,7 @@
 	<TELEM:SampleGroup name="Container_4" sampleID="4" sampleGroupID="Container_4">
 		<TELC:description>Groupname 0x16020</TELC:description>
 		<TELC:length>64</TELC:length>
-		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_ARAT" datatypeIDREF="tpkgc_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_ARAT">
+		<TELC:sample name="DIE_CSTATE_BLOCK_CAUSE_ARAT" datatypeIDREF="tdiec_block_cause" sampleID="DIE_CSTATE_BLOCK_CAUSE_ARAT">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by ARAT timers</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_BLOCK_CAUSE_ARAT</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -97,7 +97,7 @@
 			<TELC:lsb>0</TELC:lsb>
 			<TELC:msb>31</TELC:msb>
 		</TELC:sample>
-		<TELC:sample name="DIE_CSTATE_WAKE_REASON_PUNIT" datatypeIDREF="tpkgc_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_PUNIT">
+		<TELC:sample name="DIE_CSTATE_WAKE_REASON_PUNIT" datatypeIDREF="tdiec_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_PUNIT">
 			<TELC:description>Die C-state wake due to Punit</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_WAKE_REASON_PUNIT</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -109,7 +109,7 @@
 	<TELEM:SampleGroup name="Container_5" sampleID="5" sampleGroupID="Container_5">
 		<TELC:description>Groupname 0x16028</TELC:description>
 		<TELC:length>64</TELC:length>
-		<TELC:sample name="DIE_CSTATE_WAKE_REASON_RING" datatypeIDREF="tpkgc_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_RING">
+		<TELC:sample name="DIE_CSTATE_WAKE_REASON_RING" datatypeIDREF="tdiec_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_RING">
 			<TELC:description>Die C-state wake due to SNOOP</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_WAKE_REASON_RING</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -117,7 +117,7 @@
 			<TELC:lsb>0</TELC:lsb>
 			<TELC:msb>31</TELC:msb>
 		</TELC:sample>
-		<TELC:sample name="DIE_CSTATE_WAKE_REASON_SB" datatypeIDREF="tpkgc_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_SB">
+		<TELC:sample name="DIE_CSTATE_WAKE_REASON_SB" datatypeIDREF="tdiec_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_SB">
 			<TELC:description>Die C-state wake due to any SB transaction</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_WAKE_REASON_SB</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -129,7 +129,7 @@
 	<TELEM:SampleGroup name="Container_6" sampleID="6" sampleGroupID="Container_6">
 		<TELC:description>Groupname 0x16030</TELC:description>
 		<TELC:length>64</TELC:length>
-		<TELC:sample name="DIE_CSTATE_WAKE_REASON_CORE" datatypeIDREF="tpkgc_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_CORE">
+		<TELC:sample name="DIE_CSTATE_WAKE_REASON_CORE" datatypeIDREF="tdiec_wake_cause" sampleID="DIE_CSTATE_WAKE_REASON_CORE">
 			<TELC:description>Die C-state wake due to TIMER expiry</TELC:description>
 			<TELC:sampleSubGroup>DIE_CSTATE_WAKE_REASON_CORE</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -137,7 +137,7 @@
 			<TELC:lsb>0</TELC:lsb>
 			<TELC:msb>31</TELC:msb>
 		</TELC:sample>
-		<TELC:sample name="BLOCK_CAUSE_CATEGORY_TIMER" datatypeIDREF="tpkgc_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_TIMER">
+		<TELC:sample name="BLOCK_CAUSE_CATEGORY_TIMER" datatypeIDREF="tdiec_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_TIMER">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by TIMER.</TELC:description>
 			<TELC:sampleSubGroup>BLOCK_CAUSE_CATEGORY_TIMER</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -149,7 +149,7 @@
 	<TELEM:SampleGroup name="Container_7" sampleID="7" sampleGroupID="Container_7">
 		<TELC:description>Groupname 0x16038</TELC:description>
 		<TELC:length>64</TELC:length>
-		<TELC:sample name="BLOCK_CAUSE_CATEGORY_DEMOTION" datatypeIDREF="tpkgc_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_DEMOTION">
+		<TELC:sample name="BLOCK_CAUSE_CATEGORY_DEMOTION" datatypeIDREF="tdiec_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_DEMOTION">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by DEMOTION.</TELC:description>
 			<TELC:sampleSubGroup>BLOCK_CAUSE_CATEGORY_DEMOTION</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -157,7 +157,7 @@
 			<TELC:lsb>0</TELC:lsb>
 			<TELC:msb>31</TELC:msb>
 		</TELC:sample>
-		<TELC:sample name="BLOCK_CAUSE_CATEGORY_MISC" datatypeIDREF="tpkgc_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_MISC">
+		<TELC:sample name="BLOCK_CAUSE_CATEGORY_MISC" datatypeIDREF="tdiec_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_MISC">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by MISC.</TELC:description>
 			<TELC:sampleSubGroup>BLOCK_CAUSE_CATEGORY_MISC</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -169,7 +169,7 @@
 	<TELEM:SampleGroup name="Container_8" sampleID="8" sampleGroupID="Container_8">
 		<TELC:description>Groupname 0x16040</TELC:description>
 		<TELC:length>64</TELC:length>
-		<TELC:sample name="BLOCK_CAUSE_CATEGORY_IP_BUSY" datatypeIDREF="tpkgc_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_IP_BUSY">
+		<TELC:sample name="BLOCK_CAUSE_CATEGORY_IP_BUSY" datatypeIDREF="tdiec_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_IP_BUSY">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by IP_BUSY.</TELC:description>
 			<TELC:sampleSubGroup>BLOCK_CAUSE_CATEGORY_IP_BUSY</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>
@@ -177,7 +177,7 @@
 			<TELC:lsb>0</TELC:lsb>
 			<TELC:msb>31</TELC:msb>
 		</TELC:sample>
-		<TELC:sample name="BLOCK_CAUSE_CATEGORY_HYSTERSIS" datatypeIDREF="tpkgc_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_HYSTERSIS">
+		<TELC:sample name="BLOCK_CAUSE_CATEGORY_HYSTERSIS" datatypeIDREF="tdiec_block_cause" sampleID="BLOCK_CAUSE_CATEGORY_HYSTERSIS">
 			<TELC:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by HYSTERESIS.</TELC:description>
 			<TELC:sampleSubGroup>BLOCK_CAUSE_CATEGORY_HYSTERSIS</TELC:sampleSubGroup>
 			<TELC:sampleType>Counter</TELC:sampleType>

--- a/xml/MTL/3/mtl_aggregator_interface.xml
+++ b/xml/MTL/3/mtl_aggregator_interface.xml
@@ -17,19 +17,21 @@
 			</TransFormParameters>
 			<transform>$parameter_0 / 38.4 * 1e6 </transform>
 		</TransFormation>
-		<TransFormation name="pkgc_wake_cause" transformID="pkgc_wake_cause">
+		<TransFormation name="diec_wake_cause" transformID="diec_wake_cause">
 			<output_dataclass>float</output_dataclass>
 			<TransFormParameters>
 				<parameterName>parameter_0</parameterName>
+				<parameterName>parameter_1</parameterName>
 			</TransFormParameters>
-			<transform>$parameter_0 / PACKAGE_CSTATE_WAKE_REFCNT * 100 </transform>
+			<transform>$parameter_0 / $parameter_1 * 100 </transform>
 		</TransFormation>
-		<TransFormation name="pkgc_block_cause" transformID="pkgc_block_cause">
+		<TransFormation name="diec_block_cause" transformID="diec_block_cause">
 			<output_dataclass>float</output_dataclass>
 			<TransFormParameters>
 				<parameterName>parameter_0</parameterName>
+				<parameterName>parameter_1</parameterName>
 			</TransFormParameters>
-			<transform>$parameter_0 / PACKAGE_CSTATE_BLOCK_REFCNT * 100 </transform>
+			<transform>$parameter_0 / $parameter_1 * 100 </transform>
 		</TransFormation>
 		<TransFormation name="wp_volts" transformID="wp_volts">
 			<output_dataclass>float</output_dataclass>
@@ -248,7 +250,7 @@
 	<TELI:uniqueid>0x1A067102</TELI:uniqueid>
 	<TELI:NDA>Public</TELI:NDA>
 	<TELI:samplePeriod>10</TELI:samplePeriod>
-	<TELI:revisionDate>2023-11-28</TELI:revisionDate>
+	<TELI:revisionDate>2024-09-06</TELI:revisionDate>
 	<TELI:AggregatorSamples>
 		<TELI:T_AggregatorSample sampleName="XTAL" sampleGroup="XTAL" datatypeIDREF="txtal_time" sampleID="0">
 			<TELI:description>Crystal clock count. Used as a reference count in converting many of the counters presented in this telemetry space.</TELI:description>
@@ -283,7 +285,7 @@
 			</TransFormInputs>
 			<TELI:transformREF>event_counter</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_CORE" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_CORE" datatypeIDREF="tpkgc_block_cause" sampleID="3">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_CORE" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_CORE" datatypeIDREF="tdiec_block_cause" sampleID="3">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by CORE</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -291,10 +293,14 @@
 					<sampleGroupIDREF>Container_2</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_BLOCK_CAUSE_CORE</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_RING" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_RING" datatypeIDREF="tpkgc_block_cause" sampleID="4">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_RING" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_RING" datatypeIDREF="tdiec_block_cause" sampleID="4">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by RING</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -302,10 +308,14 @@
 					<sampleGroupIDREF>Container_2</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_BLOCK_CAUSE_RING</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_GPSB" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_GPSB" datatypeIDREF="tpkgc_block_cause" sampleID="5">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_GPSB" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_GPSB" datatypeIDREF="tdiec_block_cause" sampleID="5">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by GPSB</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -313,10 +323,14 @@
 					<sampleGroupIDREF>Container_3</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_BLOCK_CAUSE_GPSB</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_PUNIT" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_PUNIT" datatypeIDREF="tpkgc_block_cause" sampleID="6">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_PUNIT" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_PUNIT" datatypeIDREF="tdiec_block_cause" sampleID="6">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by PUNIT</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -324,10 +338,14 @@
 					<sampleGroupIDREF>Container_3</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_BLOCK_CAUSE_PUNIT</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_ARAT" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_ARAT" datatypeIDREF="tpkgc_block_cause" sampleID="7">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_BLOCK_CAUSE_ARAT" sampleGroup="DIE_CSTATE_BLOCK_CAUSE_ARAT" datatypeIDREF="tdiec_block_cause" sampleID="7">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by ARAT timers</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -335,10 +353,14 @@
 					<sampleGroupIDREF>Container_4</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_BLOCK_CAUSE_ARAT</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_PUNIT" sampleGroup="DIE_CSTATE_WAKE_REASON_PUNIT" datatypeIDREF="tpkgc_wake_cause" sampleID="8">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_PUNIT" sampleGroup="DIE_CSTATE_WAKE_REASON_PUNIT" datatypeIDREF="tdiec_wake_cause" sampleID="8">
 			<TELI:description>Die C-state wake due to Punit</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -346,10 +368,14 @@
 					<sampleGroupIDREF>Container_4</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_WAKE_REASON_PUNIT</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_WAKE_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_wake_cause</TELI:transformREF>
+			<TELI:transformREF>diec_wake_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_RING" sampleGroup="DIE_CSTATE_WAKE_REASON_RING" datatypeIDREF="tpkgc_wake_cause" sampleID="9">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_RING" sampleGroup="DIE_CSTATE_WAKE_REASON_RING" datatypeIDREF="tdiec_wake_cause" sampleID="9">
 			<TELI:description>Die C-state wake due to SNOOP</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -357,10 +383,14 @@
 					<sampleGroupIDREF>Container_5</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_WAKE_REASON_RING</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_WAKE_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_wake_cause</TELI:transformREF>
+			<TELI:transformREF>diec_wake_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_SB" sampleGroup="DIE_CSTATE_WAKE_REASON_SB" datatypeIDREF="tpkgc_wake_cause" sampleID="10">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_SB" sampleGroup="DIE_CSTATE_WAKE_REASON_SB" datatypeIDREF="tdiec_wake_cause" sampleID="10">
 			<TELI:description>Die C-state wake due to any SB transaction</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -368,10 +398,14 @@
 					<sampleGroupIDREF>Container_5</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_WAKE_REASON_SB</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_WAKE_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_wake_cause</TELI:transformREF>
+			<TELI:transformREF>diec_wake_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_CORE" sampleGroup="DIE_CSTATE_WAKE_REASON_CORE" datatypeIDREF="tpkgc_wake_cause" sampleID="11">
+		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_WAKE_REASON_CORE" sampleGroup="DIE_CSTATE_WAKE_REASON_CORE" datatypeIDREF="tdiec_wake_cause" sampleID="11">
 			<TELI:description>Die C-state wake due to TIMER expiry</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -379,10 +413,14 @@
 					<sampleGroupIDREF>Container_6</sampleGroupIDREF>
 					<sampleIDREF>DIE_CSTATE_WAKE_REASON_CORE</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_WAKE_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_wake_cause</TELI:transformREF>
+			<TELI:transformREF>diec_wake_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_TIMER" sampleGroup="BLOCK_CAUSE_CATEGORY_TIMER" datatypeIDREF="tpkgc_block_cause" sampleID="12">
+		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_TIMER" sampleGroup="BLOCK_CAUSE_CATEGORY_TIMER" datatypeIDREF="tdiec_block_cause" sampleID="12">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by TIMER.</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -390,10 +428,14 @@
 					<sampleGroupIDREF>Container_6</sampleGroupIDREF>
 					<sampleIDREF>BLOCK_CAUSE_CATEGORY_TIMER</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_DEMOTION" sampleGroup="BLOCK_CAUSE_CATEGORY_DEMOTION" datatypeIDREF="tpkgc_block_cause" sampleID="13">
+		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_DEMOTION" sampleGroup="BLOCK_CAUSE_CATEGORY_DEMOTION" datatypeIDREF="tdiec_block_cause" sampleID="13">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by DEMOTION.</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -401,10 +443,14 @@
 					<sampleGroupIDREF>Container_7</sampleGroupIDREF>
 					<sampleIDREF>BLOCK_CAUSE_CATEGORY_DEMOTION</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_MISC" sampleGroup="BLOCK_CAUSE_CATEGORY_MISC" datatypeIDREF="tpkgc_block_cause" sampleID="14">
+		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_MISC" sampleGroup="BLOCK_CAUSE_CATEGORY_MISC" datatypeIDREF="tdiec_block_cause" sampleID="14">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by MISC.</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -412,10 +458,14 @@
 					<sampleGroupIDREF>Container_7</sampleGroupIDREF>
 					<sampleIDREF>BLOCK_CAUSE_CATEGORY_MISC</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_IP_BUSY" sampleGroup="BLOCK_CAUSE_CATEGORY_IP_BUSY" datatypeIDREF="tpkgc_block_cause" sampleID="15">
+		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_IP_BUSY" sampleGroup="BLOCK_CAUSE_CATEGORY_IP_BUSY" datatypeIDREF="tdiec_block_cause" sampleID="15">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by IP_BUSY.</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -423,10 +473,14 @@
 					<sampleGroupIDREF>Container_8</sampleGroupIDREF>
 					<sampleIDREF>BLOCK_CAUSE_CATEGORY_IP_BUSY</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
-		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_HYSTERSIS" sampleGroup="BLOCK_CAUSE_CATEGORY_HYSTERSIS" datatypeIDREF="tpkgc_block_cause" sampleID="16">
+		<TELI:T_AggregatorSample sampleName="BLOCK_CAUSE_CATEGORY_HYSTERSIS" sampleGroup="BLOCK_CAUSE_CATEGORY_HYSTERSIS" datatypeIDREF="tdiec_block_cause" sampleID="16">
 			<TELI:description>Counts the number of 1ms intervals during which DieC entry was blocked at least once by HYSTERESIS.</TELI:description>
 			<TELI:SampleType>Counter</TELI:SampleType>
 			<TransFormInputs xmlns="http://schemas.intel.com/telemetry/base/common">
@@ -434,8 +488,12 @@
 					<sampleGroupIDREF>Container_8</sampleGroupIDREF>
 					<sampleIDREF>BLOCK_CAUSE_CATEGORY_HYSTERSIS</sampleIDREF>
 				</TransFormInput>
+				<TransFormInput varName="parameter_1">
+					<sampleGroupIDREF>Container_1</sampleGroupIDREF>
+					<sampleIDREF>DIE_CSTATE_BLOCK_REFCNT</sampleIDREF>
+				</TransFormInput>
 			</TransFormInputs>
-			<TELI:transformREF>pkgc_block_cause</TELI:transformREF>
+			<TELI:transformREF>diec_block_cause</TELI:transformREF>
 		</TELI:T_AggregatorSample>
 		<TELI:T_AggregatorSample sampleName="DIE_CSTATE_LTR_THRESHOLDS_DC2p1" sampleGroup="DIE_CSTATE_LTR_THRESHOLDS_DC2p1" datatypeIDREF="tltr" sampleID="17">
 			<TELI:description>Die C State LTR thresholds.</TELI:description>

--- a/xml/MTL/3/mtl_common.xml
+++ b/xml/MTL/3/mtl_common.xml
@@ -25,6 +25,20 @@
 			</TELC:units>
 		<TELC:format>ANY</TELC:format>
 	</TELC:dataType>
+	<TELC:dataType name="tdiec_wake_cause" datatypeID="tdiec_wake_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
+	<TELC:dataType name="tdiec_block_cause" datatypeID="tdiec_block_cause">
+		<TELC:dataclass>counter</TELC:dataclass>
+			<TELC:units name="percent">
+				<TELC:symbol>%</TELC:symbol>
+			</TELC:units>
+		<TELC:format>ANY</TELC:format>
+	</TELC:dataType>
 	<TELC:dataType name="twp_volts" datatypeID="twp_volts">
 		<TELC:dataclass>status</TELC:dataclass>
 			<TELC:units name="volts">

--- a/xml/pmt.xml
+++ b/xml/pmt.xml
@@ -1,5 +1,5 @@
 <pmt>
-	<lastupdated>2024-07-23</lastupdated>
+	<lastupdated>2024-09-06</lastupdated>
 	<mappings>
 		<mapping guid="0x87b6fef1" size="13456">
 			<lastupdated>2022-09-08</lastupdated>
@@ -122,7 +122,7 @@
 			</xmlset>
 		</mapping>
 		<mapping guid="0x130670b2" size="3336">
-			<lastupdated>2023-11-28</lastupdated>
+			<lastupdated>2024-09-06</lastupdated>
 			<status>production</status>
 			<description>MTL M/P PMT Normal telemetry in Punit samples definition and transformation rules</description>
 			<xmlset>
@@ -134,7 +134,7 @@
 			</xmlset>
 		</mapping>
 		<mapping guid="0x130671b2" size="704">
-			<lastupdated>2023-11-28</lastupdated>
+			<lastupdated>2024-09-06</lastupdated>
 			<status>production</status>
 			<description>MTL M/P PMT Fixed telemetry in Punit samples definition and transformation rules</description>
 			<xmlset>
@@ -146,7 +146,7 @@
 			</xmlset>
 		</mapping>
 		<mapping guid="0x1a067002" size="1216">
-			<lastupdated>2023-11-28</lastupdated>
+			<lastupdated>2024-09-06</lastupdated>
 			<status>production</status>
 			<description>MTL M/P PMT Normal telemetry in DMU samples definition and transformation rules</description>
 			<xmlset>
@@ -158,7 +158,7 @@
 			</xmlset>
 		</mapping>
 		<mapping guid="0x1a067102" size="200">
-			<lastupdated>2023-11-28</lastupdated>
+			<lastupdated>2024-09-06</lastupdated>
 			<status>production</status>
 			<description>MTL M/P PMT Fixed telemetry in DMU samples definition and transformation rules</description>
 			<xmlset>


### PR DESCRIPTION
- remove pkgc_wake_cause and pkgc_block_cause on unused aggregator
- define diec_wake_cause and diec_block_cause for die related metric