### PR TITLE
fix: libxslt1-dev to use exact version

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY tools/docker/requirements.txt ./
 
-RUN apt-get update && apt-get install -y --no-install-recommends g++=4:12.2.0-3 gcc=4:12.2.0-3 libxslt1-dev=1.1.35-1 netcat-traditional=1.10-47 && apt-get clean \
+RUN apt-get update && apt-get install -y --no-install-recommends g++=4:12.2.0-3 gcc=4:12.2.0-3 libxslt1-dev=1.1.35-1+deb12u1 netcat-traditional=1.10-47 && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 RUN pip install --require-hashes --no-cache-dir --no-deps -r requirements.txt
 RUN apt-get remove -y g++ gcc libxslt1-dev && apt-get autoremove -y && apt-get clean \


### PR DESCRIPTION
This is to fix container build failure due to unmet dependencies. Package libxslt1-dev now points to the exact required version.